### PR TITLE
replace getDescendent function that was accidentally removed

### DIFF
--- a/lib/helpers/CustomValidator.js
+++ b/lib/helpers/CustomValidator.js
@@ -4,6 +4,18 @@ const RuleFailure = require('../RuleFailure');
 const PatternOption = require('./PatternOption');
 
 /**
+ * This function enables field names with dot notation to be
+ * used, allowing the rules to look for nested field names.
+ *
+ * @param {Object} obj  The key's object
+ * @param {String} path The option config for the field.
+ * @returns {String} The value of the field referenced in the path
+ */
+const getDescendantProp = (obj, path) => (
+  path.split('.').reduce((acc, part) => acc && acc[part], obj)
+);
+
+/**
  * Get the correct field, either the key or the object's field.
  *
  * @param {String} fieldValueSpecifier The option config for the field.
@@ -20,7 +32,7 @@ function getFieldValue(fieldValueSpecifier, key, object) {
     return key;
   }
 
-  return object[fieldValueSpecifier];
+  return getDescendantProp(object, fieldValueSpecifier);
 }
 
 /**


### PR DESCRIPTION
### Problem

No support for nested properties

### Solution

Add support for nested properties
